### PR TITLE
Add /schedule short-link redirects for Google Calendar booking

### DIFF
--- a/src/_data/schedule.json
+++ b/src/_data/schedule.json
@@ -1,0 +1,4 @@
+{
+  "30": "https://calendar.google.com/appointments/schedules/AcZssZ2M5OLuVWbhWxVBbq3fBRb02DSRke5dh3BllLPr0bPObihZ5HjHkxjjneCj_V-OJZIUtim_1LXz",
+  "45": "https://calendar.google.com/appointments/schedules/AcZssZ0qzcWEVIz-Yy0tRawet58U_Zb39XTgS6PhPysihOeV1yc8X9iqf2ukO04Z92nCB6LabIemHtJg"
+}

--- a/src/schedule.njk
+++ b/src/schedule.njk
@@ -1,0 +1,32 @@
+---
+# Generates one client-side redirect page per entry in src/_data/schedule.json.
+# GitHub Pages can't do real HTTP redirects, so each page uses meta-refresh +
+# a JS fallback to send visitors to the matching Google Calendar booking page.
+# Add a new short link by adding one line to src/_data/schedule.json.
+pagination:
+  data: schedule
+  size: 1
+  alias: slug
+permalink: "/schedule/{{ slug }}/index.html"
+eleventyExcludeFromCollections: true
+---
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="{{ schedule[slug] }}">
+  <meta http-equiv="refresh" content="0; url={{ schedule[slug] }}">
+  <script>window.location.replace("{{ schedule[slug] | safe }}");</script>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 4rem auto; max-width: 32rem; padding: 0 1rem; text-align: center; color: #333; }
+    a { color: #2b6cb0; }
+  </style>
+</head>
+<body>
+  <p>Redirecting you to my calendar…</p>
+  <p>If you aren't redirected automatically, <a href="{{ schedule[slug] }}">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds clean, shareable short links that redirect to my Google Calendar booking pages:

- `michaelwales.com/schedule/30` → 30-minute booking page
- `michaelwales.com/schedule/45` → 45-minute booking page

## How

GitHub Pages is a static host and can't issue real HTTP 301/302 redirects, so each short link is a generated HTML page that redirects client-side:

- `<meta http-equiv="refresh" content="0; …">` — primary, works without JS
- `window.location.replace(…)` — JS fallback, avoids a back-button trap
- `<link rel="canonical">` + `noindex` so the stubs aren't indexed
- visible "click here" link if both fail

### Files
- **`src/_data/schedule.json`** — link registry (slug → URL). Adding a future short link is one line.
- **`src/schedule.njk`** — single Eleventy pagination template that emits one redirect page per registry entry at `/schedule/{slug}/index.html`.

## Verified
`npm run build` writes `_site/schedule/30/` and `_site/schedule/45/` with the correct URLs substituted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)