### PR TITLE
SEO & sharing: canonical, Open Graph/Twitter, Atom feed, sitemap, per-page descriptions

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,9 +1,13 @@
 const { DateTime } = require("luxon");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+const { rssPlugin } = require("@11ty/eleventy-plugin-rss");
 
 module.exports = function(eleventyConfig) {
   // Syntax highlighting plugin (replaces highlight.js)
   eleventyConfig.addPlugin(syntaxHighlight);
+
+  // RSS/Atom feed filters (dateToRfc3339, getNewestCollectionItemDate, absoluteUrl, htmlToAbsoluteUrls)
+  eleventyConfig.addPlugin(rssPlugin);
 
   // Date formatting filters (replaces moment.js)
   eleventyConfig.addFilter("readableDate", (dateObj) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
+        "@11ty/eleventy-plugin-rss": "^3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "luxon": "^3.4.0"
       }
@@ -133,6 +134,23 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-rss": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-3.0.0.tgz",
+      "integrity": "sha512-kKW4DcR57xAyRx0e8gNhKh56ahHVEaAj8/TuXQDnw+B46ig2bWADJAlyj/GdV37IG5ja9dZ4SgKZrs/CHz6YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@11ty/eleventy-utils": "^2.0.7",
+        "@11ty/posthtml-urls": "^1.0.2",
+        "debug": "^4.4.3",
+        "posthtml": "^0.16.7"
       },
       "funding": {
         "type": "opencollective",
@@ -455,7 +473,6 @@
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1388,7 +1405,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1412,7 +1428,6 @@
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
+    "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "luxon": "^3.4.0"
   },

--- a/project_plan.md
+++ b/project_plan.md
@@ -74,14 +74,24 @@ meta description per-page (`{{ description or site.description }}`) and update
 - [ ] Give the two nav links a reliable accessible name at all widths
 
 ### 4. Cheap SEO infrastructure for a blog  `[low]` (do as one pass)
-- [ ] `<link rel="canonical" href="{{ site.url }}{{ page.url }}">` in `base.njk`
+- [x] `<link rel="canonical" href="{{ site.url }}{{ page.url }}">` in `base.njk`
       (`site.url` is defined in `site.json:4` but currently unused)
-- [ ] Open Graph + Twitter Card tags in `base.njk` (currently none → bare,
+- [x] Open Graph + Twitter Card tags in `base.njk` (currently none → bare,
       image-less link previews)
-- [ ] RSS/Atom feed — add `@11ty/eleventy-plugin-rss` + a `feed.njk`, link via
+- [x] RSS/Atom feed — add `@11ty/eleventy-plugin-rss` + a `feed.njk`, link via
       `<link rel="alternate">`
-- [ ] `sitemap.xml` template iterating the collections
-- [ ] Per-page meta descriptions (today all pages share the one global string)
+- [x] `sitemap.xml` template iterating the collections
+- [x] Per-page meta descriptions (today all pages share the one global string)
+
+> Done on branch `seo-sharing` (2026-06-29). Per-page descriptions (6 articles +
+> about + resume) with `{{ description or site.description }}` fallback; canonical,
+> Open Graph (incl. `og:image:alt` + `article:published_time`), and Twitter
+> `summary` cards (@walesmd) in `base.njk`; Atom feed at `/feed.xml`; `/sitemap.xml`
+> (excludes the `noindex` `/schedule` stubs). Adversarially verified across Atom,
+> OG/Twitter, sitemap, and regression specs — 0 real defects.
+> Note: installing the RSS plugin surfaced pre-existing dev-only `npm audit`
+> findings in Eleventy's transitive deps (not shipped to the static site); left as
+> a separate tech-debt follow-up.
 
 ### 5. Quick accessibility fixes  `[low]`
 - [ ] `<html lang="en">` (`_includes/base.njk:2` — currently bare `<html>`)

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,5 +1,9 @@
 {
   "title": "Michael Wales",
-  "description": "Engineering Leader and Open Source Advocate",
-  "url": "https://michaelwales.com"
+  "tagline": "Engineering Leader and Open Source Advocate",
+  "description": "Engineering leader with 20+ years building teams and products, now Senior Director of AI Programs at CodePath—writing on leadership, learning, and technology.",
+  "url": "https://michaelwales.com",
+  "author": "Michael Wales",
+  "image": "https://gravatar.com/avatar/533b687cf97f813c620703e41c215fd7?s=600",
+  "twitter": "walesmd"
 }

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -4,9 +4,30 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% block title %}{% endblock %} - Michael Wales</title>
-    <meta name="author" content="Michael Wales">
-    <meta name="description" content="Engineering leader with 20+ years building teams and products, now Senior Director of AI Programs at CodePath—writing on leadership, learning, and technology.">
+    <meta name="author" content="{{ site.author }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% set pageDescription = description or site.description %}
+    {% set ogType = "article" if (tags and "articles" in tags) else "website" %}
+    <meta name="description" content="{{ pageDescription }}">
+    <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+
+    <meta property="og:type" content="{{ ogType }}">
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:title" content="{{ title or site.title }}">
+    <meta property="og:description" content="{{ pageDescription }}">
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+    <meta property="og:image" content="{{ image or site.image }}">
+    <meta property="og:image:alt" content="{{ site.author }}">
+    {%- if ogType == "article" %}
+    <meta property="article:published_time" content="{{ page.date | dateToRfc3339 }}">
+    {%- endif %}
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@{{ site.twitter }}">
+    <meta name="twitter:creator" content="@{{ site.twitter }}">
+
+    <link rel="alternate" type="application/atom+xml" title="{{ site.title }} — Atom Feed" href="/feed.xml">
 
     <link rel="stylesheet" href="/styles/normalize.css">
     <link rel="stylesheet" href="/styles/ionicons.min.css">

--- a/src/about/index.md
+++ b/src/about/index.md
@@ -1,6 +1,7 @@
 ---
 title: About Me
 layout: page.njk
+description: "Michael Wales—engineering leader, Senior Director of AI Programs at CodePath, and open source advocate based in San Antonio, TX. A bit about me and how to get in touch."
 ---
 
 <div>

--- a/src/articles/getting-started-with-gulpjs/index.md
+++ b/src/articles/getting-started-with-gulpjs/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started with GulpJS
 date: 2014-02-12
+description: "Why I moved my build workflow from Grunt to Gulp—a faster, stream-based task runner where you program your tasks in plain JavaScript instead of configuring them."
 ---
 
 

--- a/src/articles/learn-web-development-first/index.md
+++ b/src/articles/learn-web-development-first/index.md
@@ -1,6 +1,7 @@
 ---
 title: Learn Web Development, First
 date: 2014-02-20
+description: "Frameworks and languages come and go; HTML, CSS, and JavaScript are the constant. A case for learning the fundamentals of the web before committing to any single stack."
 ---
 
 I recently read Rob Conery's *[PHP or ASP.NET: Did I Do The Right Thing?](http://www.wekeroad.com/2014/02/18/i-had-a-choice-php-or-net/)* Although it does a great job uncovering how a developer can literally lose half a decade of their life by focusing their efforts towards the wrong technologies, I can't help but feel as if Rob is still asking himself the wrong questions, focusing on symptoms rather than the problem itself.

--- a/src/articles/make-gitconfig-work-for-you/index.md
+++ b/src/articles/make-gitconfig-work-for-you/index.md
@@ -1,6 +1,7 @@
 ---
 title: Make .gitconfig Work for You
 date: 2014-03-19
+description: "Git's real power lives on the command line. A tour of the .gitconfig file—its scopes, aliases, and settings—to make Git work the way you do."
 ---
 
 [Git](http://git-scm.com) has undoubtedly become one of the most important tools within any Web Developer's bag of tricks, arguably due to amazing success of [GitHub](http://github.com). Unfortunately, Git can be quite overwhelming - particularly for those developers new to *distributed* version control systems.

--- a/src/articles/research-at-the-hourly-scale/index.md
+++ b/src/articles/research-at-the-hourly-scale/index.md
@@ -1,6 +1,7 @@
 ---
 title: Research at the Hourly Scale
 date: 2026-06-24
+description: "We stress-tested a year-long fellowship by simulating a synthetic cohort before any real fellow showed up—and why that kind of research happens at the hourly scale at CodePath."
 ---
 
 Talent is everywhere. Opportunity isn't. That sentence is most of the reason I joined [CodePath](https://www.codepath.org/) as Senior Director of AI Programs, and it sits underneath everything we build. CodePath has spent almost a decade taking first-generation and low-income computing students - most from households earning under $60,000 a year - and getting them into real tech careers, at about a two-in-three rate. The talent was always there. What was missing was a door.

--- a/src/articles/resurrecting-a-2014-codebase-in-2026/index.md
+++ b/src/articles/resurrecting-a-2014-codebase-in-2026/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resurrecting a 2014 Codebase in 2026
 date: 2026-01-10
+description: "Reviving a brittle, decade-old blog buried under technical debt—handing the whole repository to Claude Code and migrating from Wintersmith to a modern Eleventy build."
 ---
 
 For many developers, software projects never truly die - they just become harder and harder to touch. The code still exists; the ideas still matter; the content or functionality still has value. What disappears first is the ability to reasonably maintain that code. Over time, dependencies rot, build tools get abandoned, and the cognitive cost of even small changes steadily rises until the only sensible option seems to be "don’t touch it." That was the state of this blog - not broken in concept, but brittle and immobilized under a decade of technical debt.

--- a/src/articles/what-algorithm-runs-an-elevator/index.md
+++ b/src/articles/what-algorithm-runs-an-elevator/index.md
@@ -1,6 +1,7 @@
 ---
 title: What Algorithm Runs an Elevator?
 date: 2026-06-26
+description: "A question caught me waiting for an elevator at Universal Orlando: how does it decide who to pick up? So I built a little world to run elevators myself and find out."
 ---
 
 I was standing in the lobby of my resort at Universal Orlando, waiting for an elevator, when the question caught me. Six cars, a small crowd, buttons lighting up faster than the doors could open. One car sailed past my floor without stopping. The other doubled back for someone who'd pressed *down* after I'd pressed *up*. And I found myself doing the thing I always do when something in the world won't leave me alone: wondering exactly how it decides. What's the logic in there? When two people on different floors both want a car, who wins? Is it just first-come-first-served, or is something cleverer going on?

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -1,0 +1,26 @@
+---
+permalink: /feed.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }}</title>
+  <subtitle>{{ site.tagline }}</subtitle>
+  <link href="{{ site.url }}/feed.xml" rel="self"/>
+  <link href="{{ site.url }}/"/>
+  <updated>{{ collections.articles | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+  <id>{{ site.url }}/</id>
+  <author>
+    <name>{{ site.author }}</name>
+  </author>
+  {%- for post in collections.articles %}
+  {%- set absolutePostUrl = post.url | absoluteUrl(site.url) %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+  </entry>
+  {%- endfor %}
+</feed>

--- a/src/resume/index.md
+++ b/src/resume/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resume
 layout: resume.njk
+description: "The career of Michael Wales—an engineering leader with 20+ years across CodePath, Skylight, Guideline, Moonrise, Udacity, and the US Air Force."
 ---
 
 ## Highlights

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for item in collections.all %}
+  <url>
+    <loc>{{ site.url }}{{ item.url }}</loc>
+    <lastmod>{{ item.date | htmlDateString }}</lastmod>
+  </url>
+  {%- endfor %}
+</urlset>


### PR DESCRIPTION
## Summary

Tier 1, Task 4 of `project_plan.md` — makes the site behave like a modern content site for search engines and link sharing. Builds on the identity refresh (#6): now the *correct* identity propagates into share previews, search snippets, and a subscribable feed.

## What changed

| Area | Change |
|------|--------|
| **Per-page descriptions** | `base.njk` uses `{{ description or site.description }}`; tailored `description:` front matter added to all 6 articles + about + resume. The rich default sentence moved into `site.json`. |
| **Canonical** | `<link rel="canonical">` on every page (uses the previously-unused `site.url`). |
| **Open Graph** | `og:type` (auto `article`/`website`), `og:title`, `og:description`, `og:url`, `og:site_name`, `og:image` (gravatar @600px) + `og:image:alt`, and `article:published_time` (RFC-3339) on posts. |
| **Twitter Cards** | `summary` card wired to `@walesmd` (site + creator). |
| **RSS/Atom feed** | `@11ty/eleventy-plugin-rss` + `src/feed.njk` → `/feed.xml` (6 entries, absolute URLs), linked via `<link rel="alternate">`. |
| **Sitemap** | `src/sitemap.njk` → `/sitemap.xml` (9 URLs; excludes the `noindex` `/schedule` redirect stubs and the feed). |
| **Config / data** | `eleventy.config.js` registers the RSS plugin; `site.json` gains `tagline`, `author`, `image`, `twitter`. |

## Net effect

- Shared links (LinkedIn, Slack, iMessage, etc.) render proper previews — title + description + avatar — instead of bare text.
- Search engines get a sitemap, canonicals, and unique per-page descriptions (no more identical description on every page).
- Readers can subscribe via `/feed.xml`.

## Verification

- `npm run build` green; `feed.xml` and `sitemap.xml` well-formed (`xmllint`).
- Sitemap contains exactly the 9 indexable URLs; `/schedule` stubs correctly excluded.
- Per-page descriptions resolve distinctly; `og:type` switches `website`/`article`; canonicals correct per page.
- **Adversarial spec validation** (Atom RFC 4287, Open Graph, Twitter Cards, regression) across 4 independent validators: **0 real defects**.

## Note

Installing `@11ty/eleventy-plugin-rss` surfaced pre-existing `npm audit` warnings — all in Eleventy's transitive **dev** dependencies (liquidjs, markdown-it, ws, etc.), none from the RSS plugin. They run only at build time and don't ship to the static site. Left as a separate tech-debt follow-up rather than scope-creeping this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)