### PR TITLE
Load the Prism syntax-highlight theme only on pages that have code

### DIFF
--- a/project_plan.md
+++ b/project_plan.md
@@ -153,8 +153,30 @@ meta description per-page (`{{ description or site.description }}`) and update
   > adversarially verified (completeness, correctness, a11y, regressions) — 0 defects.
 - [x] **CLS:** article images set `width` but no `height`
       (`getting-started-with-gulpjs/index.md:9,11`).
-- [ ] 4 separate unminified/unbundled/non-cache-busted stylesheets in `<head>`
-      (`base.njk:11-14`).
+- [~] 4 separate unminified/unbundled/non-cache-busted stylesheets in `<head>`.
+
+  > **Deprioritized (2026-06-29).** A Lighthouse run showed the page is ~96% Adobe
+  > Typekit (186 KB fonts + a 764 ms render-blocking loader JS); the three local
+  > stylesheets total only ~4.9 KB gzipped, and Lighthouse reports **0 bytes** of
+  > savings from CSS minification. Bundling/minifying is a micro-optimization that
+  > wouldn't move the needle, so we're parking it. The real lever is Typekit (above,
+  > also deferred). If ever revisited, inlining the ~5 KB of CSS into `<head>` (not
+  > bundling to one external file) is the higher-leverage move.
+- [x] **Load the Prism theme only on pages with highlighted code** (perf, surfaced
+      during the 2026-06-29 Lighthouse audit). `prism-github.css` was shipped on every
+      page even though most have no code blocks.
+
+  > Done on branch `prism-conditional` (2026-06-29). Syntax highlighting is done at
+  > **build time** (the `@11ty/eleventy-plugin-syntaxhighlight` plugin bakes
+  > `class="token"`/`language-` markup into the HTML — there is no client-side Prism
+  > JS). `base.njk` now emits the `prism-github.css` `<link>` only when the rendered
+  > `content` contains `language-` markup (`{% if "language-" in (content | string) %}`).
+  > Result: the theme loads on exactly the 2 code pages (gulp, gitconfig) and is
+  > dropped from the other 10 (home, about, resume, 404, 2 schedule stubs, 4 no-code
+  > articles). Verified the invariant (link iff code) across all built pages; confirmed
+  > `prism-github.css` only targets `[class*="language-"]`/`.token`, so the
+  > language-less `resurrecting` article (bare `<pre><code>`) was never styled by it —
+  > zero visual change. Pure build-time, no client JS.
 - [x] Add a `404.html` (GitHub Pages will serve it; currently the generic default).
 
 ### More accessibility

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -34,7 +34,9 @@
     <link rel="alternate" type="application/atom+xml" title="{{ site.title }} — Atom Feed" href="/feed.xml">
 
     <link rel="stylesheet" href="/styles/normalize.css">
+    {%- if "language-" in (content | string) %}
     <link rel="stylesheet" href="/styles/prism-github.css">
+    {%- endif %}
     <link rel="stylesheet" href="/styles/style.css">
 
     <script type="text/javascript" src="https://use.typekit.net/byn8skt.js"></script>


### PR DESCRIPTION
## Summary

`prism-github.css` was linked on **every** page, but syntax highlighting is done at **build time** (the `@11ty/eleventy-plugin-syntaxhighlight` plugin bakes `class="token"`/`language-` markup into the HTML — there is **no client-side Prism JS**), and most pages have no code blocks. `base.njk` now emits the theme `<link>` only when the rendered content actually contains highlighted code:

```njk
{%- if "language-" in (content | string) %}
<link rel="stylesheet" href="/styles/prism-github.css">
{%- endif %}
```

## Result

| Pages | Loads `prism-github.css`? |
|---|---|
| `getting-started-with-gulpjs`, `make-gitconfig-work-for-you` (have `language-` code) | ✅ yes |
| home, about, resume, 404, 2× `/schedule` stubs, 4 no-code articles | ❌ dropped |

10 of 12 pages — including the homepage — now drop one render-blocking request and the `prism-github.css` transfer.

## Why it's provably safe

- **Invariant verified across every built page:** the `<link>` appears *iff* the page contains `class="language-"` markup. No code page lost its theme; no non-code page loads it.
- **The edge case** (`resurrecting-a-2014-codebase` — has code, but uses **language-less** ``` fences → bare `<pre><code>`): every selector in `prism-github.css` is scoped to `[class*="language-"]`/`.token`, so it **never** styled those bare blocks — even on `master`. Confirmed the built markup is bare `<pre>`/`<code>` with no classes. **Zero visual change.**
- **Pure build-time** Nunjucks conditional — no client JS, no new dependencies.

## Context

This came out of a Lighthouse audit. The broader CSS bundling/minification item was **deprioritized** (the local CSS is ~4.9 KB gzipped with ~0 minification savings; the page's real cost is Adobe Typekit at ~96% of weight + a render-blocking loader, which is separately deferred). Both decisions are recorded in `project_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)